### PR TITLE
Adds a copy_table function

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,22 @@ Here's the ending state of the table:
 |   6|   D|   D|
 +----+----+----+
 ```
+
+## Copy table
+
+The `copy_table` function copies an existing Delta table.
+When you copy a table, it gets recreated at a specified target. This target could be a path or a table in a metastore.
+Copying includes:
+
+* Data
+* Partitioning
+* Table properties
+
+Copying **does not** include the delta log, which means that you will not be able to restore the new table to an old version of the original table.
+
+Here's how to perform the copy:
+
+```python
+mack.copy_table(delta_table=deltaTable, target_path=path)
+```
+

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -1,4 +1,3 @@
-import delta
 from delta import *
 import pyspark
 import pyspark.sql.functions as F
@@ -106,7 +105,7 @@ def kill_duplicates(deltaTable, pkey, cols):
     ).whenMatchedDelete().execute()
 
 
-def copy_table(delta_table: delta.DeltaTable, target_path: str = None, target_table: str = None):
+def copy_table(delta_table: DeltaTable, target_path: str = None, target_table: str = None):
     if not delta_table:
         raise Exception("An existing delta table must be specified.")
 


### PR DESCRIPTION
This PR adds a new function, copy_table, that allows to copy an existing Delta Table. 
Copying includes partitions columns and all the options that are set on the origin table.

Once the changes are approved as being reasonable, I will add an update to the ReadMe. 