### PR TITLE
Adds drop_duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ Here's the ending state of the table:
 +----+----+----+
 |col1|col2|col3|
 +----+----+----+
-|   1|   A|   A| # duplicate
+|   1|   A|   A|
 |   2|   A|   B|
-|   5|   B|   B| # duplicate
+|   5|   B|   B|
 |   6|   D|   D|
 +----+----+----+
 ```

--- a/README.md
+++ b/README.md
@@ -106,6 +106,45 @@ Here's the ending state of the table:
 +----+----+----+
 ```
 
+## Drop duplicates
+
+The `drop_duplicates` function removes all but one duplicate row from a Delta table.
+
+Suppose you have the following table:
+
+```
++----+----+----+
+|col1|col2|col3|
++----+----+----+
+|   1|   A|   A| # duplicate
+|   2|   A|   B|
+|   3|   A|   A| # duplicate
+|   4|   A|   A| # duplicate
+|   5|   B|   B| # duplicate
+|   6|   D|   D|
+|   9|   B|   B| # duplicate
++----+----+----+
+```
+
+Run the `drop_duplicates` function:
+
+```python
+mack.drop_duplicates(delta_table=deltaTable, primary_key="col1", duplication_columns=["col2", "col3"])
+```
+
+Here's the ending state of the table:
+
+```
++----+----+----+
+|col1|col2|col3|
++----+----+----+
+|   1|   A|   A| # duplicate
+|   2|   A|   B|
+|   5|   B|   B| # duplicate
+|   6|   D|   D|
++----+----+----+
+```
+
 ## Copy table
 
 The `copy_table` function copies an existing Delta table.

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -1,6 +1,9 @@
+from typing import List
+
 from delta import *
 import pyspark
 import pyspark.sql.functions as F
+from pyspark.sql.window import Window
 
 
 class MackValidationError(ValueError):
@@ -102,6 +105,47 @@ def kill_duplicates(deltaTable, pkey, cols):
 
     deltaTable.alias("main").merge(
         dfTemp.alias("nodups"), q
+    ).whenMatchedDelete().execute()
+
+
+def drop_duplicates(delta_table: DeltaTable, primary_key: str, duplication_columns: List[str]):
+    if not delta_table:
+        raise Exception("An existing delta table must be specified.")
+
+    if not primary_key:
+        raise Exception("A primary key must be specified.")
+
+    if not duplication_columns or len(duplication_columns) == 0:
+        raise Exception("Duplication columns must not be empty or None.")
+
+    data_frame = delta_table.toDF()
+
+    # Make sure that all the required columns are present in the provided delta table
+    data_frame_columns = data_frame.columns
+    required_columns = [primary_key] + duplication_columns
+    for required_column in required_columns:
+        if required_column not in data_frame_columns:
+            raise MackValidationError(
+                f"The base table has these columns '{data_frame_columns}', but these columns are required '{required_columns}'"
+            )
+
+    # Get all the duplicate records
+    duplicate_records = (
+        data_frame
+        .withColumn("row_number", F.row_number().over(Window().partitionBy(duplication_columns).orderBy(primary_key)))
+        .filter(F.col("row_number") > 1)
+        .drop("row_number")
+        .distinct()
+    ).cache()
+
+    q = [f"old.{primary_key} = new.{primary_key}"]
+    for column in duplication_columns:
+        q.append(f"old.{column} = new.{column}")
+    q = " AND ".join(q)
+
+    # Remove all the duplicate records
+    delta_table.alias("old").merge(
+        duplicate_records.alias("new"), q
     ).whenMatchedDelete().execute()
 
 

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -335,6 +335,37 @@ def test_kills_duplicates_in_a_delta_table(tmp_path):
     chispa.assert_df_equality(res, expected, ignore_row_order=True)
 
 
+def test_drop_duplicates_in_a_delta_table(tmp_path):
+    path = f"{tmp_path}/drop_duplicates"
+    data = [
+        (1, "A", "A", "C"),  # duplicate
+        (2, "A", "B", "C"),
+        (3, "A", "A", "D"),  # duplicate
+        (4, "A", "A", "E"),  # duplicate
+        (5, "B", "B", "C"),  # duplicate
+        (6, "D", "D", "C"),
+        (9, "B", "B", "E"),  # duplicate
+    ]
+    df = spark.createDataFrame(data, ["col1", "col2", "col3", "col4"])
+    df.write.format("delta").save(path)
+
+    deltaTable = DeltaTable.forPath(spark, path)
+
+    mack.drop_duplicates(deltaTable, "col1", ["col2", "col3"])
+
+    res = spark.read.format("delta").load(path)
+
+    expected_data = [
+        (1, "A", "A", "C"),  # duplicate
+        (2, "A", "B", "C"),
+        (5, "B", "B", "C"),  # duplicate
+        (6, "D", "D", "C"),
+    ]
+    expected = spark.createDataFrame(expected_data, ["col1", "col2", "col3", "col4"])
+
+    chispa.assert_df_equality(res, expected, ignore_row_order=True)
+
+
 def test_copy_delta_table(tmp_path):
     path = f"{tmp_path}/copy_test_1"
     data = [

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -356,9 +356,9 @@ def test_drop_duplicates_in_a_delta_table(tmp_path):
     res = spark.read.format("delta").load(path)
 
     expected_data = [
-        (1, "A", "A", "C"),  # duplicate
+        (1, "A", "A", "C"),
         (2, "A", "B", "C"),
-        (5, "B", "B", "C"),  # duplicate
+        (5, "B", "B", "C"),
         (6, "D", "D", "C"),
     ]
     expected = spark.createDataFrame(expected_data, ["col1", "col2", "col3", "col4"])


### PR DESCRIPTION
This PR adds a new function, drop_duplicates, that drops all but one duplicate row from a Delta table. 
This relates to Issue  #3 .
