### PR TITLE
Remove primary key as parameter from kill_duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Suppose you have the following table:
 Run the `kill_duplicates` function:
 
 ```python
-mack.kill_duplicates(deltaTable, "col1", ["col2", "col3"])
+mack.kill_duplicates(deltaTable, ["col2", "col3"])
 ```
 
 Here's the ending state of the table:

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -111,9 +111,9 @@ def kill_duplicates(delta_table: DeltaTable, duplication_columns: List[str] = No
 
     duplicate_records = (
         data_frame
-        .withColumn("duplicate", F.count("*").over(Window.partitionBy(duplication_columns)))
-        .filter(F.col("duplicate") > 1)
-        .drop("duplicate")
+        .withColumn("amount_of_records", F.count("*").over(Window.partitionBy(duplication_columns)))
+        .filter(F.col("amount_of_records") > 1)
+        .drop("amount_of_records")
         .distinct()
     )
 

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -351,7 +351,7 @@ def test_drop_duplicates_in_a_delta_table(tmp_path):
 
     deltaTable = DeltaTable.forPath(spark, path)
 
-    mack.drop_duplicates(deltaTable, ["col2", "col3"])
+    mack.drop_duplicates(deltaTable, "col1", ["col2", "col3"])
 
     res = spark.read.format("delta").load(path)
 

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -319,7 +319,7 @@ def test_kills_duplicates_in_a_delta_table(tmp_path):
 
     deltaTable = DeltaTable.forPath(spark, path)
 
-    mack.kill_duplicates(deltaTable, "col1", ["col2", "col3"])
+    mack.kill_duplicates(deltaTable, ["col3", "col2"])
 
     res = spark.read.format("delta").load(path)
 
@@ -351,7 +351,7 @@ def test_drop_duplicates_in_a_delta_table(tmp_path):
 
     deltaTable = DeltaTable.forPath(spark, path)
 
-    mack.drop_duplicates(deltaTable, "col1", ["col2", "col3"])
+    mack.drop_duplicates(deltaTable, ["col2", "col3"])
 
     res = spark.read.format("delta").load(path)
 


### PR DESCRIPTION
@MrPowers it was fairly easy to refactor the `kill_duplicates` function, but I do not see a way to have`drop_duplicates` work without a UUID column that we can reference in the merge condition. The only thing I can come up with is overwriting the table, which would be highly inefficient. Do you have any ideas on that; maybe I have missed something obvious? 

cc: #8 