### PR TITLE
Add delta_file_sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,22 @@ Here's the ending result:
 ```
 
 Notice that the duplicate `col1` value was not appended.  If a normal append operation was run, then the Delta table would contain two rows of data with `col1` equal to 2.
+
+## Delta File Sizes
+
+The `delta_file_sizes` function prints the amount of files and the average file size for a delta table.
+
+Suppose you have the following Delta Table, partitioned by `col1`:
+
+```
++----+----+----+
+|col1|col2|col3|
++----+----+----+
+|   1|   A|   A|
+|   2|   A|   B|
++----+----+----+
+```
+
+Running `mack.delta_file_sizes(delta_table)` on that table will print:
+
+`The delta table contains 2 files. The average file size in bytes is 660.0`

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ mack.type_2_scd_upsert(path, updatesDF, "pkey", ["attr1", "attr2"])
 
 ## Type 2 SCD Upserts
 
-This library provides an opinionated, conventions over configuration, approach to Type 2 SCD management.  Let's look at an example before covering the conventions required to take advantage of the functionality.
+This library provides an opinionated, conventions over configuration, approach to Type 2 SCD management. Let's look at an example before
+covering the conventions required to take advantage of the functionality.
 
 Suppose you have the following SCD table with the `pkey` primary key:
 
@@ -155,7 +156,8 @@ Copying includes:
 * Partitioning
 * Table properties
 
-Copying **does not** include the delta log, which means that you will not be able to restore the new table to an old version of the original table.
+Copying **does not** include the delta log, which means that you will not be able to restore the new table to an old version of the original
+table.
 
 Here's how to perform the copy:
 
@@ -165,7 +167,8 @@ mack.copy_table(delta_table=deltaTable, target_path=path)
 
 ## Append data without duplicates
 
-The `append_without_duplicates` function helps to append records to a existing Delta table without getting duplicates appended to the record.
+The `append_without_duplicates` function helps to append records to a existing Delta table without getting duplicates appended to the
+record.
 
 Suppose you have the following Delta table:
 
@@ -198,6 +201,7 @@ mack.append_without_duplicates(deltaTable, append_df, ["col1"])
 ```
 
 Here's the ending result:
+
 ```
 
 +----+----+----+
@@ -211,11 +215,13 @@ Here's the ending result:
 +----+----+----+
 ```
 
-Notice that the duplicate `col1` value was not appended.  If a normal append operation was run, then the Delta table would contain two rows of data with `col1` equal to 2.
+Notice that the duplicate `col1` value was not appended. If a normal append operation was run, then the Delta table would contain two rows
+of data with `col1` equal to 2.
 
 ## Delta File Sizes
 
-The `delta_file_sizes` function prints the amount of files and the average file size for a given Delta Table.
+The `delta_file_sizes` function returns a dictionary that contains the total size in bytes, the amount of files and the average file size
+for a given Delta Table.
 
 Suppose you have the following Delta Table, partitioned by `col1`:
 
@@ -228,6 +234,8 @@ Suppose you have the following Delta Table, partitioned by `col1`:
 +----+----+----+
 ```
 
-Running `mack.delta_file_sizes(delta_table)` on that table will print:
+Running `mack.delta_file_sizes(delta_table)` on that table will return:
 
-`This Delta Table contains 2 files. The average file size in bytes is 660.0`
+`{"size_in_bytes": 1320,
+"number_of_files": 2,
+"average_file_size_in_bites": 660}`

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Notice that the duplicate `col1` value was not appended.  If a normal append ope
 
 ## Delta File Sizes
 
-The `delta_file_sizes` function prints the amount of files and the average file size for a delta table.
+The `delta_file_sizes` function prints the amount of files and the average file size for a given Delta Table.
 
 Suppose you have the following Delta Table, partitioned by `col1`:
 
@@ -230,4 +230,4 @@ Suppose you have the following Delta Table, partitioned by `col1`:
 
 Running `mack.delta_file_sizes(delta_table)` on that table will print:
 
-`The delta table contains 2 files. The average file size in bytes is 660.0`
+`This Delta Table contains 2 files. The average file size in bytes is 660.0`

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -262,5 +262,5 @@ def delta_file_sizes(delta_table: DeltaTable):
     average_file_size = round(total_file_size / number_of_files, 0)
 
     print(
-        f"The delta table contains {number_of_files} files. The average file size in bytes is {average_file_size}"
+        f"This Delta Table contains {number_of_files} files. The average file size in bytes is {average_file_size}"
     )

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -254,3 +254,13 @@ def append_without_duplicates(
     delta_table.alias("old").merge(
         append_data.alias("new"), condition_columns
     ).whenNotMatchedInsertAll().execute()
+
+
+def delta_file_sizes(delta_table: DeltaTable):
+    details = delta_table.detail().select("numFiles", "sizeInBytes").collect()[0]
+    total_file_size, number_of_files = details["sizeInBytes"], details["numFiles"]
+    average_file_size = round(total_file_size / number_of_files, 0)
+
+    print(
+        f"The delta table contains {number_of_files} files. The average file size in bytes is {average_file_size}"
+    )

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -258,9 +258,11 @@ def append_without_duplicates(
 
 def delta_file_sizes(delta_table: DeltaTable):
     details = delta_table.detail().select("numFiles", "sizeInBytes").collect()[0]
-    total_file_size, number_of_files = details["sizeInBytes"], details["numFiles"]
-    average_file_size = round(total_file_size / number_of_files, 0)
+    size_in_bytes, number_of_files = details["sizeInBytes"], details["numFiles"]
+    average_file_size_in_bites = round(size_in_bytes / number_of_files, 0)
 
-    print(
-        f"This Delta Table contains {number_of_files} files. The average file size in bytes is {average_file_size}"
-    )
+    return {
+        "size_in_bytes": size_in_bytes,
+        "number_of_files": number_of_files,
+        "average_file_size_in_bites": average_file_size_in_bites,
+    }

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -471,7 +471,7 @@ def test_append_without_duplicates_multi_column(tmp_path):
     chispa.assert_df_equality(appended_data, expected, ignore_row_order=True)
 
 
-def test_describe_table(capfd, tmp_path):
+def test_describe_table(tmp_path):
     path = f"{tmp_path}/copy_test_1"
     data = [
         (1, "A", "A"),
@@ -488,11 +488,12 @@ def test_describe_table(capfd, tmp_path):
 
     delta_table = DeltaTable.forPath(spark, path)
 
-    mack.delta_file_sizes(delta_table)
+    result = mack.delta_file_sizes(delta_table)
 
-    out, _ = capfd.readouterr()
+    expected_result = {
+        "size_in_bytes": 1320,
+        "number_of_files": 2,
+        "average_file_size_in_bites": 660,
+    }
 
-    assert (
-        out
-        == "This Delta Table contains 2 files. The average file size in bytes is 660.0\n"
-    )
+    assert result == expected_result

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -494,5 +494,5 @@ def test_describe_table(capfd, tmp_path):
 
     assert (
         out
-        == "The delta table contains 2 files. The average file size in bytes is 660.0\n"
+        == "This Delta Table contains 2 files. The average file size in bytes is 660.0\n"
     )


### PR DESCRIPTION
This PR adds the delta_file_sizes method, which prints the number of files and the average file sizes for a given Delta Table.

cc: #16 