### PR TITLE
Add a humanize_bytes function to make large numbers of bytes readable

### DIFF
--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -275,3 +275,16 @@ def append_without_duplicates(
     delta_table.alias("old").merge(
         append_data.alias("new"), condition_columns
     ).whenNotMatchedInsertAll().execute()
+
+
+def humanize_bytes(n: int) -> str:
+    for prefix, k in (
+        ("PB", 1e15),
+        ("TB", 1e12),
+        ("GB", 1e9),
+        ("MB", 1e6),
+        ("kB", 1e3),
+    ):
+        if n >= k * 0.9:
+            return f"{n / k:.2f} {prefix}"
+    return f"{n} B"

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -511,3 +511,10 @@ def test_append_without_duplicates_multi_column(tmp_path):
     ]
     expected = spark.createDataFrame(expected_data, ["col1", "col2", "col3"])
     chispa.assert_df_equality(appended_data, expected, ignore_row_order=True)
+
+# humanize bytes
+def test_humanize_bytes_formats_nicely():
+    assert(mack.humanize_bytes(12345678) == "12.35 MB")
+    assert(mack.humanize_bytes(1234567890) == "1.23 GB")
+    assert(mack.humanize_bytes(1234567890000) == "1.23 TB")
+    assert(mack.humanize_bytes(1234567890000000) == "1.23 PB")


### PR DESCRIPTION
We're going to expose some functions that will return large numbers of bytes.  The purpose of this helper function is to make those large numbers of bytes human readable.