### PR TITLE
humanize delta_file_sizes

### DIFF
--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -346,10 +346,14 @@ def delta_file_sizes(delta_table: DeltaTable):
     size_in_bytes, number_of_files = details["sizeInBytes"], details["numFiles"]
     average_file_size_in_bytes = round(size_in_bytes / number_of_files, 0)
 
+    humanized_size_in_bytes = humanize_bytes(size_in_bytes)
+    humanized_number_of_files = f"{number_of_files:,}"
+    humanized_average_file_size = humanize_bytes(average_file_size_in_bytes)
+
     return {
-        "size_in_bytes": size_in_bytes,
-        "number_of_files": number_of_files,
-        "average_file_size_in_bytes": average_file_size_in_bytes,
+        "size": humanized_size_in_bytes,
+        "number_of_files": humanized_number_of_files,
+        "average_file_size": humanized_average_file_size,
     }
 
 

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -628,9 +628,9 @@ def test_describe_table(tmp_path):
     result = mack.delta_file_sizes(delta_table)
 
     expected_result = {
-        "size_in_bytes": 1320,
-        "number_of_files": 2,
-        "average_file_size_in_bytes": 660,
+        "size": "1.32 kB",
+        "number_of_files": "2",
+        "average_file_size": "660.0 B",
     }
 
     assert result == expected_result


### PR DESCRIPTION
The `delta_file_sizes` function is a nice wrapper over the `DeltaTable.detail()` [method](https://docs.delta.io/latest/api/python/index.html#delta.tables.DeltaTable.detail). 

Before this PR, the value that `delta_file_sizes` gave over `detail()` was to do some simple division and rounding.

This PR is a bit opinionated, as it asserts that the `delta_file_sizes` function should be used for the purpose of humans, not machines. We keep the dividing and rounding functionality while "humanizing" the outputs by converting the units and adding commas to large numbers. 