### PR TITLE
Change SCD functions to take DeltaTable instead of Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You'd like to perform an upsert with this data:
 Here's how to perform the upsert:
 
 ```scala
-mack.type_2_scd_upsert(path, updatesDF, "pkey", ["attr1", "attr2"])
+mack.type_2_scd_upsert(delta_table, updatesDF, "pkey", ["attr1", "attr2"])
 ```
 
 Here's the table after the upsert:

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -9,16 +9,13 @@ from pyspark.sql.window import Window
 
 
 def type_2_scd_upsert(
-    delta_table: DeltaTable,
-    updates_df: DataFrame,
-    primary_key: str,
-    attr_col_names: List[str],
+    path: str, updates_df: DataFrame, primary_key: str, attr_col_names: List[str]
 ) -> None:
     """
     <description>
 
     :param path: <description>
-    :type path: DeltaTable
+    :type path: str
     :param updates_df: <description>
     :type updates_df: DataFrame
     :param primary_key: <description>
@@ -30,7 +27,7 @@ def type_2_scd_upsert(
     :rtype: None
     """
     return type_2_scd_generic_upsert(
-        delta_table,
+        path,
         updates_df,
         primary_key,
         attr_col_names,
@@ -41,7 +38,7 @@ def type_2_scd_upsert(
 
 
 def type_2_scd_generic_upsert(
-    delta_table: DeltaTable,
+    path: str,
     updates_df: DataFrame,
     primary_key: str,
     attr_col_names: List[str],
@@ -52,7 +49,7 @@ def type_2_scd_generic_upsert(
     """
     <description>
 
-    :param delta_table: DeltaTable
+    :param path: <description>
     :type path: str
     :param updates_df: <description>
     :type updates_df: DataFrame
@@ -73,9 +70,10 @@ def type_2_scd_generic_upsert(
     :returns: <description>
     :rtype: None
     """
+    base_table = DeltaTable.forPath(pyspark.sql.SparkSession.getActiveSession(), path)
 
     # validate the existing Delta table
-    base_col_names = delta_table.toDF().columns
+    base_col_names = base_table.toDF().columns
     required_base_col_names = (
         [primary_key]
         + attr_col_names
@@ -106,7 +104,7 @@ def type_2_scd_generic_upsert(
     staged_updates_attrs = " OR ".join(staged_updates_attrs)
     staged_part_1 = (
         updates_df.alias("updates")
-        .join(delta_table.toDF().alias("base"), primary_key)
+        .join(base_table.toDF().alias("base"), primary_key)
         .where(f"base.{is_current_col_name} = true AND ({updates_attrs})")
         .selectExpr("NULL as mergeKey", "updates.*")
     )
@@ -123,7 +121,7 @@ def type_2_scd_generic_upsert(
     }
     res_thing = {**thing, **thing2}
     res = (
-        delta_table.alias("base")
+        base_table.alias("base")
         .merge(
             source=staged_updates.alias("staged_updates"),
             condition=pyspark.sql.functions.expr(
@@ -492,6 +490,30 @@ def delta_file_sizes(delta_table: DeltaTable) -> Dict[str, int]:
         "number_of_files": number_of_files,
         "average_file_size_in_bytes": average_file_size_in_bytes,
     }
+
+
+def show_delta_file_sizes(delta_table: DeltaTable) -> None:
+    """
+    <description>
+
+    :param delta_table: <description>
+    :type delta_table: DeltaTable
+
+    :returns: <description>
+    :rtype: None
+    """
+    details = delta_table.detail().select("numFiles", "sizeInBytes").collect()[0]
+    size_in_bytes, number_of_files = details["sizeInBytes"], details["numFiles"]
+    average_file_size_in_bytes = round(size_in_bytes / number_of_files, 0)
+
+    humanized_size_in_bytes = humanize_bytes(size_in_bytes)
+    humanized_number_of_files = f"{number_of_files:,}"
+    humanized_average_file_size = humanize_bytes(average_file_size_in_bytes)
+
+    print(
+        f"The delta table contains {humanized_number_of_files} files with a size of {humanized_size_in_bytes}."
+        + f" The average file size is {humanized_average_file_size}"
+    )
 
 
 def humanize_bytes(n: int) -> str:

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -9,13 +9,16 @@ from pyspark.sql.window import Window
 
 
 def type_2_scd_upsert(
-    path: str, updates_df: DataFrame, primary_key: str, attr_col_names: List[str]
+    delta_table: DeltaTable,
+    updates_df: DataFrame,
+    primary_key: str,
+    attr_col_names: List[str],
 ) -> None:
     """
     <description>
 
     :param path: <description>
-    :type path: str
+    :type path: DeltaTable
     :param updates_df: <description>
     :type updates_df: DataFrame
     :param primary_key: <description>
@@ -27,7 +30,7 @@ def type_2_scd_upsert(
     :rtype: None
     """
     return type_2_scd_generic_upsert(
-        path,
+        delta_table,
         updates_df,
         primary_key,
         attr_col_names,
@@ -38,7 +41,7 @@ def type_2_scd_upsert(
 
 
 def type_2_scd_generic_upsert(
-    path: str,
+    delta_table: DeltaTable,
     updates_df: DataFrame,
     primary_key: str,
     attr_col_names: List[str],
@@ -49,7 +52,7 @@ def type_2_scd_generic_upsert(
     """
     <description>
 
-    :param path: <description>
+    :param delta_table: DeltaTable
     :type path: str
     :param updates_df: <description>
     :type updates_df: DataFrame
@@ -70,10 +73,9 @@ def type_2_scd_generic_upsert(
     :returns: <description>
     :rtype: None
     """
-    base_table = DeltaTable.forPath(pyspark.sql.SparkSession.getActiveSession(), path)
 
     # validate the existing Delta table
-    base_col_names = base_table.toDF().columns
+    base_col_names = delta_table.toDF().columns
     required_base_col_names = (
         [primary_key]
         + attr_col_names
@@ -104,7 +106,7 @@ def type_2_scd_generic_upsert(
     staged_updates_attrs = " OR ".join(staged_updates_attrs)
     staged_part_1 = (
         updates_df.alias("updates")
-        .join(base_table.toDF().alias("base"), primary_key)
+        .join(delta_table.toDF().alias("base"), primary_key)
         .where(f"base.{is_current_col_name} = true AND ({updates_attrs})")
         .selectExpr("NULL as mergeKey", "updates.*")
     )
@@ -121,7 +123,7 @@ def type_2_scd_generic_upsert(
     }
     res_thing = {**thing, **thing2}
     res = (
-        base_table.alias("base")
+        delta_table.alias("base")
         .merge(
             source=staged_updates.alias("staged_updates"),
             condition=pyspark.sql.functions.expr(

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -60,7 +60,8 @@ def test_upserts_with_single_attribute(tmp_path):
     )
     updates_df = spark.createDataFrame(data=updates_data, schema=updates_schema)
 
-    mack.type_2_scd_upsert(path, updates_df, "pkey", ["attr"])
+    delta_table = DeltaTable.forPath(spark, path)
+    mack.type_2_scd_upsert(delta_table, updates_df, "pkey", ["attr"])
 
     actual_df = spark.read.format("delta").load(path)
 
@@ -110,8 +111,9 @@ def test_errors_out_if_base_df_does_not_have_all_required_columns(tmp_path):
     )
     updates_df = spark.createDataFrame(data=updates_data, schema=updates_schema)
 
+    delta_table = DeltaTable.forPath(spark, path)
     with pytest.raises(TypeError):
-        mack.type_2_scd_upsert(path, updates_df, "pkey", ["attr"])
+        mack.type_2_scd_upsert(delta_table, updates_df, "pkey", ["attr"])
 
 
 def test_errors_out_if_updates_table_does_not_contain_all_required_columns(tmp_path):
@@ -146,8 +148,9 @@ def test_errors_out_if_updates_table_does_not_contain_all_required_columns(tmp_p
     )
     updates_df = spark.createDataFrame(data=updates_data, schema=updates_schema)
 
+    delta_table = DeltaTable.forPath(spark, path)
     with pytest.raises(TypeError):
-        mack.type_2_scd_upsert(path, updates_df, "pkey", ["attr"])
+        mack.type_2_scd_upsert(delta_table, updates_df, "pkey", ["attr"])
 
 
 def test_upserts_based_on_multiple_attributes(tmp_path):
@@ -184,7 +187,8 @@ def test_upserts_based_on_multiple_attributes(tmp_path):
     )
     updates_df = spark.createDataFrame(data=updates_data, schema=updates_schema)
 
-    mack.type_2_scd_upsert(path, updates_df, "pkey", ["attr1", "attr2"])
+    delta_table = DeltaTable.forPath(spark, path)
+    mack.type_2_scd_upsert(delta_table, updates_df, "pkey", ["attr1", "attr2"])
 
     actual_df = spark.read.format("delta").load(path)
 
@@ -235,8 +239,9 @@ def test_upserts_based_on_date_columns(tmp_path):
     ).toDF("pkey", "attr", "effective_date")
 
     # perform upsert
+    delta_table = DeltaTable.forPath(spark, path)
     mack.type_2_scd_generic_upsert(
-        path, updates_df, "pkey", ["attr"], "cur", "effective_date", "end_date"
+        delta_table, updates_df, "pkey", ["attr"], "cur", "effective_date", "end_date"
     )
 
     actual_df = spark.read.format("delta").load(path)
@@ -287,8 +292,15 @@ def test_upserts_based_on_version_number(tmp_path):
     ).toDF("pkey", "attr", "effective_ver")
 
     # perform upsert
+    delta_table = DeltaTable.forPath(spark, path)
     mack.type_2_scd_generic_upsert(
-        path, updates_df, "pkey", ["attr"], "is_current", "effective_ver", "end_ver"
+        delta_table,
+        updates_df,
+        "pkey",
+        ["attr"],
+        "is_current",
+        "effective_ver",
+        "end_ver",
     )
 
     # show result

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -60,8 +60,7 @@ def test_upserts_with_single_attribute(tmp_path):
     )
     updates_df = spark.createDataFrame(data=updates_data, schema=updates_schema)
 
-    delta_table = DeltaTable.forPath(spark, path)
-    mack.type_2_scd_upsert(delta_table, updates_df, "pkey", ["attr"])
+    mack.type_2_scd_upsert(path, updates_df, "pkey", ["attr"])
 
     actual_df = spark.read.format("delta").load(path)
 
@@ -111,9 +110,8 @@ def test_errors_out_if_base_df_does_not_have_all_required_columns(tmp_path):
     )
     updates_df = spark.createDataFrame(data=updates_data, schema=updates_schema)
 
-    delta_table = DeltaTable.forPath(spark, path)
     with pytest.raises(TypeError):
-        mack.type_2_scd_upsert(delta_table, updates_df, "pkey", ["attr"])
+        mack.type_2_scd_upsert(path, updates_df, "pkey", ["attr"])
 
 
 def test_errors_out_if_updates_table_does_not_contain_all_required_columns(tmp_path):
@@ -148,9 +146,8 @@ def test_errors_out_if_updates_table_does_not_contain_all_required_columns(tmp_p
     )
     updates_df = spark.createDataFrame(data=updates_data, schema=updates_schema)
 
-    delta_table = DeltaTable.forPath(spark, path)
     with pytest.raises(TypeError):
-        mack.type_2_scd_upsert(delta_table, updates_df, "pkey", ["attr"])
+        mack.type_2_scd_upsert(path, updates_df, "pkey", ["attr"])
 
 
 def test_upserts_based_on_multiple_attributes(tmp_path):
@@ -187,8 +184,7 @@ def test_upserts_based_on_multiple_attributes(tmp_path):
     )
     updates_df = spark.createDataFrame(data=updates_data, schema=updates_schema)
 
-    delta_table = DeltaTable.forPath(spark, path)
-    mack.type_2_scd_upsert(delta_table, updates_df, "pkey", ["attr1", "attr2"])
+    mack.type_2_scd_upsert(path, updates_df, "pkey", ["attr1", "attr2"])
 
     actual_df = spark.read.format("delta").load(path)
 
@@ -239,9 +235,8 @@ def test_upserts_based_on_date_columns(tmp_path):
     ).toDF("pkey", "attr", "effective_date")
 
     # perform upsert
-    delta_table = DeltaTable.forPath(spark, path)
     mack.type_2_scd_generic_upsert(
-        delta_table, updates_df, "pkey", ["attr"], "cur", "effective_date", "end_date"
+        path, updates_df, "pkey", ["attr"], "cur", "effective_date", "end_date"
     )
 
     actual_df = spark.read.format("delta").load(path)
@@ -292,15 +287,8 @@ def test_upserts_based_on_version_number(tmp_path):
     ).toDF("pkey", "attr", "effective_ver")
 
     # perform upsert
-    delta_table = DeltaTable.forPath(spark, path)
     mack.type_2_scd_generic_upsert(
-        delta_table,
-        updates_df,
-        "pkey",
-        ["attr"],
-        "is_current",
-        "effective_ver",
-        "end_ver",
+        path, updates_df, "pkey", ["attr"], "is_current", "effective_ver", "end_ver"
     )
 
     # show result
@@ -620,8 +608,8 @@ def test_is_composite_key_candidate(tmp_path):
     assert mack.is_composite_key_candidate(delta_table, ["col1", "col2"])
 
 
-def test_describe_table(tmp_path):
-    path = f"{tmp_path}/copy_test_1"
+def test_delta_file_sizes(tmp_path):
+    path = f"{tmp_path}/delta_file_sizes"
     data = [
         (1, "A", "A"),
         (2, "A", "B"),
@@ -646,6 +634,28 @@ def test_describe_table(tmp_path):
     }
 
     assert result == expected_result
+
+
+def test_show_delta_file_sizes(capfd, tmp_path):
+    path = f"{tmp_path}/show_delta_file_sizes"
+    data = [
+        (1, "A", "A"),
+        (2, "A", "B"),
+    ]
+    df = spark.createDataFrame(data, ["col1", "col2", "col3"])
+
+    (df.write.format("delta").partitionBy(["col1"]).save(path))
+
+    delta_table = DeltaTable.forPath(spark, path)
+
+    mack.show_delta_file_sizes(delta_table)
+
+    out, _ = capfd.readouterr()
+
+    assert (
+        out
+        == "The delta table contains 2 files with a size of 1.32 kB. The average file size is 660.0 B\n"
+    )
 
 
 def test_humanize_bytes_formats_nicely():


### PR DESCRIPTION
Resolves #65 

Includes:
- Changing functions to take delta_table instead of path
- Update tests to pass DeltaTables instead of paths to said functions.
- update code snippet in readme that references path for said functions.

P.S: Please forgive the extra commit & revert, accidentally merged poorly but all should be in order now :) 