### PR TITLE
correcting function name in readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Suppose you have the following table:
 Run the `drop_duplicates` function:
 
 ```python
-mack.drop_duplicates_pkey(delta_table=deltaTable, duplication_columns=["col1"])
+mack.drop_duplicates(delta_table=deltaTable, duplication_columns=["col1"])
 ```
 
 Here's the ending state of the table:


### PR DESCRIPTION
Resolves #66 

Includes:
- Correcting wrong function name in README.md docs.

Comment:
I haven't run the pre-commit hooks as it's only a minor docs change.