### PR TITLE
Add Docker and docker-compose envrionment for mack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:20.04
+
+ENV TZ=America/Chicago
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends default-jdk software-properties-common python3-pip python3.9 python3.9-dev libpq-dev build-essential wget libssl-dev libffi-dev vim && \
+    apt-get clean
+
+RUN wget https://archive.apache.org/dist/spark/spark-3.3.2/spark-3.3.2-bin-hadoop3.tgz && \
+    tar xvf spark-3.3.2-bin-hadoop3.tgz && \
+    mv spark-3.3.2-bin-hadoop3/ /usr/local/spark && \
+    ln -s /usr/local/spark spark
+
+WORKDIR app
+COPY . /app
+
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 2
+RUN  update-alternatives --config python3
+
+RUN pip3 install poetry delta-spark
+RUN poetry install
+
+ENV PYSPARK_PYTHON=python3
+ENV PYSPARK_SUBMIT_ARGS='--packages io.delta:delta-core_2.12:2.2.0 pyspark-shell'

--- a/README.md
+++ b/README.md
@@ -520,6 +520,14 @@ Here are some of the code design principles used in Mack:
 * We try to make functions that are easy to copy.  We do this by limiting functions that depend on other functions or classes.  We'd rather nest a single use function in a public interface method than make it separate.
 * Develop and then abstract.  All code goes in a single file till the right abstractions become apparent.  We'd rather have a large file than the wrong abstractions.
 
+### Docker Environment
+The `Dockerfile` and `docker-compose` files provide a containerized way to run and develop
+with `mack`.
+
+- The first time run `docker build --tag=mack .` to build the image.
+- To execute the unit tests inside the `Docker` container, run `docker-compose up test`
+- To drop into the running `Docker` container to develop, run `docker run -it mack /bin/bash`
+
 ## Community
 
 ### Blogs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: "3.9"
+services:
+  test:
+    image: "mack"
+    volumes:
+      - .:/app
+    command: poetry run pytest


### PR DESCRIPTION
The purpose of this PR is to add support for developing and running `mack` with `Docker`. This will ease the burden of development and setting up a local environment that includes Spark, for example.

1. Add a `ubuntu` based `Dockerfile` that contains Spark `3.3.2` as well as PySpark arguments that will load `delta-core_2.12:2.2.0`.
2. Add a `docker-compose` file that allows for running of `unit-tests` via a container. `docker-compose up test`
3. Add instructions to the `README`.