### PR TITLE
Add notnull constraint append

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,11 +472,17 @@ mack.latest_version(delta_table)
 
 ## Append data with constraints
 
-The `constraint_append` function helps to append records to an existing Delta table even if there are records in the append dataframe that violate table constraints, these records are appended to an existing quarantine Delta table instead of the target table. If the quarantine Delta table is set to `None`, those records that violate table constraints are simply thrown out.
+The `constraint_append` function helps to append records to an existing Delta table even if there are records in the append dataframe that violate table constraints (both check and not null constraints), these records are appended to an existing quarantine Delta table instead of the target table. If the quarantine Delta table is set to `None`, those records that violate table constraints are simply thrown out.
 
-Suppose you have the following target Delta table with these constraints:
+Suppose you have the following target Delta table with the following schema and constraints:
 
 ```
+schema:
+col1 int not null
+col2 string null
+col3 string null
+
+check constraints:
 col1_constraint: (col1 > 0)
 col2_constraint: (col2 != 'Z')
 
@@ -497,6 +503,7 @@ Here is data to be appended:
 +----+----+----+
 |col1|col2|col3|
 +----+----+----+
+|    |   H|   H| # violates col1 not null constraint
 |   0|   Z|   Z| # violates both col1_constraint and col2_constraint
 |   4|   A|   B|
 |   5|   C|   D|
@@ -536,6 +543,7 @@ Here's the ending result in quarantine_table:
 +----+----+----+
 |col1|col2|col3|
 +----+----+----+
+|    |   H|   H|
 |   0|   Z|   Z|
 |  11|   Z|   Z|
 +----+----+----+

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -657,9 +657,17 @@ def constraint_append(
         )
 
     properties = delta_table.detail().select("properties").collect()[0]["properties"]
-    constraints = [
+    check_constraints = [
         v for k, v in properties.items() if k.startswith("delta.constraints")
     ]
+
+    # add null checks
+    fields = delta_table.toDF().schema.fields
+    null_constraints = [
+        f"{field.name} is not null" for field in fields if not field.nullable
+    ]
+
+    constraints = check_constraints + null_constraints
 
     if not constraints:
         raise TypeError("There are no constraints present in the target delta table")


### PR DESCRIPTION
Added the feature to include NOT NULL constraint checks in the constraint_append function. issue number: https://github.com/MrPowers/mack/issues/100

Changes:

- Modified constraint_append function to include not null checks 
- Added unit test for not null testing
- Updated the README

Note: The feature is aiming to check NOT NULL constraints defined at the schema level and not as explicit table constraints. Explicit table constraints are already checked in the current version of the constraint_append function.
