### PR TITLE
Fix for Issue #2

### DIFF
--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -126,15 +126,14 @@ def type_2_scd_generic_upsert(
         delta_table.alias("base")
         .merge(
             source=staged_updates.alias("staged_updates"),
-            condition=pyspark.sql.functions.expr(
-                f"base.{primary_key} = mergeKey AND base.{is_current_col_name} = true AND ({staged_updates_attrs})"
-            ),
+            condition=pyspark.sql.functions.expr(f"base.{primary_key} = mergeKey"),
         )
         .whenMatchedUpdate(
+            condition=f"base.{is_current_col_name} = true AND ({staged_updates_attrs})",
             set={
                 is_current_col_name: "false",
                 end_time_col_name: f"staged_updates.{effective_time_col_name}",
-            }
+            },
         )
         .whenNotMatchedInsert(values=res_thing)
         .execute()


### PR DESCRIPTION
These changes were made with assistance from @Amrit-Hub's comment about the upsert logic. Existing logic assumes that if there is a matching primary key and match columns have changed then update, else insert. This assumes we won't pass an existing PK with unchanged values in match columns, which could lead to duplicate records being inserted each run of the upsert. By altering the logic to only consider the PK as the match condition we can push the logic for updating further down and avoid unintentionally re-inserting records with same PK/match-column combination that were unchanged from last upsert attempt.