### PR TITLE
Fix rename function, simplify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ chispa.egg-info/
 tmp/
 .idea/
 .DS_Store
+*.parquet
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ Notice that the records that violated either of the constraints are appended to 
 
 ## Rename a Delta Table
 
-This function is designed to rename a Delta table. It can operate either within a Databricks environment or with a standalone Spark session. 
+This function is designed to rename a Delta table. It can operate either within a Databricks environment or with a standalone Spark session.
 
 Here are the parameters for the function:
 

--- a/mack/__init__.py
+++ b/mack/__init__.py
@@ -695,33 +695,22 @@ def constraint_append(
 
 
 def rename_delta_table(
-    delta_table: DeltaTable,
+    old_table_name: str,
     new_table_name: str,
     spark_session: SparkSession = SparkSession.getActiveSession(),
 ) -> None:
     """
-    Renames a Delta table to a new name. This function can be used in a Databricks environment or with a
-    standalone Spark session.
+    Renames a Delta table to a new name.
 
     Parameters:
-    delta_table (DeltaTable): The DeltaTable object representing the table to be renamed.
+    old_table_name (str): The old name for the table.
     new_table_name (str): The new name for the table.
     spark (pyspark.sql.SparkSession, optional): The Spark session. Defaults to active SparkSession.
 
     Returns:
     None
 
-    Raises:
-    TypeError: If the provided `delta_table` is not a DeltaTable object, or if `databricks` is True
-        and `spark_session` is None.
-
     Example Usage:
-    >>> rename_delta_table(delta_table, "new_table_name")
+    >>> rename_delta_table("old_table_name", "new_table_name")
     """
-    if not isinstance(delta_table, DeltaTable):
-        raise TypeError("An existing delta table must be specified for delta_table.")
-    spark_session.sql(f"ALTER TABLE {delta_table.name} RENAME TO {new_table_name}")
-    # else:
-    #     delta_table.toDF().write.format("delta").mode("overwrite").saveAsTable(
-    #         new_table_name
-    #     )
+    spark_session.sql(f"ALTER TABLE {old_table_name} RENAME TO {new_table_name}")

--- a/tests/test_public_interface.py
+++ b/tests/test_public_interface.py
@@ -1142,27 +1142,18 @@ def test_constraint_append_notnull_and_check_constraint(tmp_path):
         quarantined_data, expected_quarantined_df, ignore_row_order=True
     )
 
-    
+
 def test_rename_delta_table(tmp_path):
-    # Create a temporary directory to hold the Delta table
-    # Create a sample DataFrame
     data = [("Alice", 1), ("Bob", 2)]
     df = spark.createDataFrame(data, ["Name", "Age"])
-
-    # Write the DataFrame to a Delta table
     old_table_name = "old_table"
-    df.write.format("delta").save(old_table_name)
+    df.write.mode("overwrite").format("delta").saveAsTable(old_table_name)
 
-    # Load the Delta table
-    old_table = DeltaTable.forName(spark, old_table_name)
-
-    # Call the function to rename the Delta table
     new_table_name = "new_table"
-    mack.rename_delta_table(old_table, new_table_name)
+    mack.rename_delta_table(old_table_name, new_table_name, spark)
 
     # Verify the table has been renamed
     assert spark._jsparkSession.catalog().tableExists(new_table_name)
 
     # Clean up: Drop the new table
     spark.sql(f"DROP TABLE IF EXISTS {new_table_name}")
-


### PR DESCRIPTION
@MrPowers I'm not sure what I was thinking in the initial PR, i think it was overcomplicated trying to support both SparkSessions and non-SparkSessions with just DeltaLake standalone reader.

This PR into yours makes it more simple, just a simple SparkSession rename of the DeltaTable. Take a look at the passing Unit Test, do you think this ALTER TABLE NAME will persist past the current SparkSession it's running in?